### PR TITLE
Fix mayavi build failure by downgrading VTK to 9.3.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,9 @@ jobs:
         run: |
           (cd mayavi; git fetch origin; git checkout main; git reset --hard origin/main; git branch -a)
           pip3 install -U pip setuptools
-          pip3 install -r ./requirements.txt
+          pip3 install vtk==9.3.1
+          pip3 install --no-build-isolation -e ./mayavi
+          pip3 install Sphinx==9.1.0 "sphinx-intl[transifex]==2.3.2"
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
           mv tx /usr/local/bin/tx
       - name: update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,8 +42,7 @@ jobs:
           (cd mayavi; git fetch origin; git checkout main; git reset --hard origin/main; git branch -a)
           pip3 install -U pip setuptools
           pip3 install vtk==9.3.1
-          pip3 install --no-build-isolation -e ./mayavi
-          pip3 install Sphinx==9.1.0 "sphinx-intl[transifex]==2.3.2"
+          pip3 install --no-build-isolation -r ./requirements.txt
           curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
           mv tx /usr/local/bin/tx
       - name: update

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,6 +10,10 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+  jobs:
+    pre_install:
+      - pip install vtk==9.3.1
+      - pip install --no-build-isolation -e ./mayavi
 
 submodules:
   include:

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,7 +13,8 @@ build:
   jobs:
     pre_install:
       - pip install vtk==9.3.1
-      - pip install --no-build-isolation -e ./mayavi
+    install:
+      - pip install --no-build-isolation -r requirements.txt
 
 submodules:
   include:
@@ -23,8 +24,3 @@ submodules:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: conf.py
-
-# Optionally declare the Python requirements required to build your docs
-python:
-  install:
-    - requirements: requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--e ./mayavi
 Sphinx==9.1.0
 sphinx-intl[transifex]==2.3.2
 vtk==9.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 -e ./mayavi
 Sphinx==9.1.0
 sphinx-intl[transifex]==2.3.2
-vtk==9.5.2
+vtk==9.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+-e ./mayavi
 Sphinx==9.1.0
 sphinx-intl[transifex]==2.3.2
 vtk==9.3.1


### PR DESCRIPTION
## Summary

- Downgrade `vtk==9.5.2` to `vtk==9.3.1` in `requirements.txt`
- VTK 9.4+ has known segfault issues during mayavi's tvtk wrapper generation (`ENABLE_FIELD_RECOGNITION` property not found, exit code -6)
- Use `--no-build-isolation` when installing mayavi so the pre-installed VTK 9.3.1 is used during the editable build instead of the latest VTK from an isolated build environment

## Root cause

The CI run https://github.com/tkoyama010/mayavi-doc-translations/actions/runs/23368215516 failed with:
```
ERROR: Could not find property 'ENABLE_FIELD_RECOGNITION'
Fatal Python error: Aborted
```
This is a known incompatibility between VTK 9.4+ and mayavi's tvtk wrapper generation. VTK 9.3.1 is the last stable version compatible with the current mayavi codebase.

## Test plan

- [ ] CI passes on this PR
- [ ] The `install` step completes without errors
- [ ] The `update` step runs successfully

Generated with [Claude Code](https://claude.com/claude-code)